### PR TITLE
Session parquet files

### DIFF
--- a/create_session_parquet_files.py
+++ b/create_session_parquet_files.py
@@ -6,20 +6,32 @@ from astropy.table import Table, vstack
 import pandas as pd
 import numpy as np
 
+# regular expression to match the session name given a path to antenna FITS file
 SESSION_REGEX = re.compile(r"/[^/]*/Antenna")
 
 def group_files_df(manifest_path: str):
     """Returns a pd dataframe with one column containing all the paths listed in the manifest file, and
     another column containing each file's associated session"""
-    df = pd.DataFrame(open(manifest_path, "r").readlines(), columns=["path"])
+    lines = open(manifest_path, "r").readlines()
+    df = pd.DataFrame(lines, columns=["path"])
     df["path"] = df["path"].map(lambda x: x.replace("\n", ""))
+    # get session name
     df["session"] = df["path"].map(lambda x: re.search(SESSION_REGEX, x).group(0).split("/")[1])
     return df
 
 
+def create_session_antenna_df(df, session):
+    """Generates a dataframe containing the antenna position data for a given session"""
+    sliced = df[df["session"] == session]
+    table_list = []
+    for path in sliced["path"]:
+        table_list.append(Table.read(path, hdu=2)[["DMJD", "RAJ2000", "DECJ2000"]])
+    return vstack(table_list).to_pandas()
+        
+
 def create_parquets(antenna_session_manifest_path: str, output_dir: str):
     """Generates a tree with output_dir as the root and subdirectories for each session, each containing
-    a parquet file with combined scan FITS files"""
+    a parquet file with combined antenna position data"""
     
     os.makedirs(output_dir)
 
@@ -31,19 +43,19 @@ def create_parquets(antenna_session_manifest_path: str, output_dir: str):
         session_dir = os.path.join(output_dir, session)
         os.makedirs(session_dir)
 
-        sliced = df[df["session"] == session]
-        table_list = []
-        for path in sliced["path"]:
-            table_list.append(Table.read(path, hdu=2)[["DMJD", "RAJ2000", "DECJ2000"]])
-        sliced_df = vstack(table_list).to_pandas()
+        sliced_df = create_session_antenna_df(df, session)
         sliced_df.to_parquet(''.join([os.path.join(session_dir, session), ".parquet"]))
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("antenna_session_manifest_path", help="The files containing the paths to antenna FITS files")
-parser.add_argument("output_dir", help="The created directory containing the tree of parquet files")
-args = parser.parse_args()
-manifest_path = str(args.antenna_session_manifest_path)
-output_dir = str(args.output_dir)
-create_parquets(manifest_path, output_dir)
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("antenna_session_manifest_path", help="The files containing the paths to antenna FITS files")
+    parser.add_argument("output_dir", help="The created directory containing the tree of parquet files")
+    args = parser.parse_args()
+    manifest_path = str(args.antenna_session_manifest_path)
+    output_dir = str(args.output_dir)
+    create_parquets(manifest_path, output_dir)
 
+
+if __name__ == "__main__":
+    main()

--- a/create_session_parquet_files.py
+++ b/create_session_parquet_files.py
@@ -1,62 +1,58 @@
 import argparse
 from pathlib import Path
+from collections import defaultdict
 
 from astropy.table import Table, vstack
-import pandas as pd
-import numpy as np
 
 
-# df groupby
-# default dict
-# break up functions so easier to test
-
-
-def group_files_df(manifest_path: Path | str):
-    """Returns a pd dataframe with one column containing all the paths listed in the manifest file, and
-    another column containing each file's associated session"""
+def group_files(manifest_path: Path):
+    """Generates a dictionary grouping FITS file paths with their associated GBT session"""
+    
+    d: defaultdict[str, list[Path]] = defaultdict(list)
     with open(manifest_path, "r") as file:
-        rows = ((path.rstrip("\n"), Path(path).parent.parent.name) for path in file)
-        return pd.DataFrame(rows, columns=["path", "session"])
-
-
-def create_session_antenna_df(df, session):
-    """Generates a dataframe containing the antenna position data for a given session"""
-    sliced = df[df["session"] == session]
-    table_list = []
-    for path in sliced["path"]:
-        table_list.append(Table.read(path, hdu=2)[["DMJD", "RAJ2000", "DECJ2000"]])
-    return vstack(table_list).to_pandas()
+        {d[Path(path).parent.parent.name].append(Path(path.rstrip("\n"))) for path in file}   
+    return dict(d)
         
 
-def create_parquets(antenna_session_manifest_path: str, output_dir: str):
+def create_session_table(paths: list[Path]):
+    """Combines antenna positions from a list of FITS files into one dataframe"""
+    table_list = []
+    for path in paths:
+        table_list.append(Table.read(path, hdu=2, format='fits')[["DMJD", "RAJ2000", "DECJ2000"]])
+    return vstack(table_list).to_pandas()
+
+
+def create_parquets_dict(antenna_session_manifest_path: Path, output_dir: Path):
     """Generates a tree with output_dir as the root and subdirectories for each session, each containing
     a parquet file with combined antenna position data"""
     
-    df = group_files_df(antenna_session_manifest_path)
-    sessions = np.unique(df["session"])
-
-    for session in sessions:
+    session_dict = group_files(antenna_session_manifest_path)
+    
+    for session in session_dict:
 
         session_dir = Path(output_dir, session)
         Path.mkdir(session_dir, parents=True, exist_ok=True)
 
-        sliced_df = create_session_antenna_df(df, session)
-        sliced_df.to_parquet(f"{Path(session_dir, session)}.parquet")
+        sliced_df = create_session_table(session_dict[session])
+        parquet_path = f"{Path(session_dir, session)}.parquet"
+        sliced_df.to_parquet(parquet_path)
+        print(f"Wrote {parquet_path}")
 
 
 def parse_arguments():
+    """Parses and returns arguments from the command line"""
     parser = argparse.ArgumentParser()
     parser.add_argument("antenna_session_manifest_path", type=Path, help="The files containing the paths to antenna FITS files")
     parser.add_argument("output_dir", type=Path, help="The created directory containing the tree of parquet files")
     args = parser.parse_args()
-    manifest_path = str(args.antenna_session_manifest_path)
-    output_dir = str(args.output_dir)
+    manifest_path = args.antenna_session_manifest_path
+    output_dir = args.output_dir
     return manifest_path, output_dir
 
 
 def main():
     manifest_path, output_dir = parse_arguments()
-    create_parquets(manifest_path, output_dir)
+    create_parquets_dict(manifest_path, output_dir)
 
 
 if __name__ == "__main__":

--- a/create_session_parquet_files.py
+++ b/create_session_parquet_files.py
@@ -1,0 +1,49 @@
+import os
+import argparse
+import re
+
+from astropy.table import Table, vstack
+import pandas as pd
+import numpy as np
+
+SESSION_REGEX = re.compile(r"/[^/]*/Antenna")
+
+def group_files_df(manifest_path: str):
+    """Returns a pd dataframe with one column containing all the paths listed in the manifest file, and
+    another column containing each file's associated session"""
+    df = pd.DataFrame(open(manifest_path, "r").readlines(), columns=["path"])
+    df["path"] = df["path"].map(lambda x: x.replace("\n", ""))
+    df["session"] = df["path"].map(lambda x: re.search(SESSION_REGEX, x).group(0).split("/")[1])
+    return df
+
+
+def create_parquets(antenna_session_manifest_path: str, output_dir: str):
+    """Generates a tree with output_dir as the root and subdirectories for each session, each containing
+    a parquet file with combined scan FITS files"""
+    
+    os.makedirs(output_dir)
+
+    df = group_files_df(antenna_session_manifest_path)
+    sessions = np.unique(df["session"])
+
+    for session in sessions:
+
+        session_dir = os.path.join(output_dir, session)
+        os.makedirs(session_dir)
+
+        sliced = df[df["session"] == session]
+        table_list = []
+        for path in sliced["path"]:
+            table_list.append(Table.read(path, hdu=2)[["DMJD", "RAJ2000", "DECJ2000"]])
+        sliced_df = vstack(table_list).to_pandas()
+        sliced_df.to_parquet(''.join([os.path.join(session_dir, session), ".parquet"]))
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("antenna_session_manifest_path", help="The files containing the paths to antenna FITS files")
+parser.add_argument("output_dir", help="The created directory containing the tree of parquet files")
+args = parser.parse_args()
+manifest_path = str(args.antenna_session_manifest_path)
+output_dir = str(args.output_dir)
+create_parquets(manifest_path, output_dir)
+


### PR DESCRIPTION
In `create_session_parquet_files.py`, the paths in the ant_fits.txt file are read into a dataframe, with a second column containing their respective sessions. It iterates through unique sessions to stack FITS data and generate parquet files. (There's probably a more efficient way to do this though)